### PR TITLE
fix permissions for chrome

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
 
   "manifest_version": 3,
 
-  "permissions": ["webRequest", "storage"],
+  "permissions": ["tabs", "storage"],
 
   // sets an add-on ID
   "browser_specific_settings": {


### PR DESCRIPTION

Summary:

Had the wrong permissions to query tabs. But somehow on Firefox that worked nevertheless. In Chrome it does not.

Test Plan:

Temporary install in chrome. See that domains are now resolved correctly and not all data is attributed to the "unknown" domain.
